### PR TITLE
Bump SIDScore CLI version to 0.7.1

### DIFF
--- a/net.resheim.sidscore/pom.xml
+++ b/net.resheim.sidscore/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>sidscore-cli</artifactId>
   <name>SIDScoreCLI</name>
-  <version>0.7.0</version>
+  <version>0.7.1</version>
   <groupId>net.resheim.sidscore</groupId>
   <packaging>jar</packaging>
   <properties>


### PR DESCRIPTION
## Summary

- Bump the SIDScore CLI Maven project version from `0.7.0` to `0.7.1`.

## Root Cause

The `main` branch publish workflow attempted to deploy `net.resheim.sidscore:sidscore-cli:0.7.0` after PR #9 was merged. GitHub Packages already contains that version, so Maven deploy failed with a `409 Conflict`.

## Impact

The next publish run will deploy a new patch version instead of retrying the already-published `0.7.0` artifact.

## Validation

- `mvn -B -f net.resheim.sidscore/pom.xml -DskipTests package`